### PR TITLE
Remove edit actions from Problem card

### DIFF
--- a/ui/src/components/Editor/EditorControls/BetaListItem.tsx
+++ b/ui/src/components/Editor/EditorControls/BetaListItem.tsx
@@ -3,7 +3,6 @@ import {
   ListItem,
   ListItemIcon,
   ListItemText,
-  Menu,
   MenuItem,
   Radio,
   Skeleton,
@@ -11,13 +10,12 @@ import {
 import {
   ContentCopy as IconContentCopy,
   Delete as IconDelete,
-  MoreVert as IconMoreVert,
 } from "@mui/icons-material";
 import { graphql, useFragment } from "react-relay";
 import { BetaListItem_betaNode$key } from "./__generated__/BetaListItem_betaNode.graphql";
 import Editable from "components/common/Editable";
 import { isDefined } from "util/func";
-import TooltipIconButton from "components/common/TooltipIconButton";
+import ActionsMenu from "components/common/ActionsMenu";
 
 interface Props {
   betaKey: BetaListItem_betaNode$key;
@@ -49,13 +47,7 @@ const BetaListItem: React.FC<Props> = ({
     betaKey
   );
 
-  const [actionsAnchorEl, setActionsAnchorEl] =
-    React.useState<null | HTMLElement>(null);
-  const actionsOpen = Boolean(actionsAnchorEl);
   const controlId = useId();
-  const menuId = useId();
-
-  const onCloseActions = (): void => setActionsAnchorEl(null);
 
   return (
     <ListItem
@@ -87,25 +79,7 @@ const BetaListItem: React.FC<Props> = ({
         secondary={`${beta.moves.edges.length} moves`}
       />
 
-      <TooltipIconButton
-        title="Beta Actions"
-        aria-controls={actionsOpen ? menuId : undefined}
-        aria-haspopup
-        aria-expanded={actionsOpen}
-        onClick={(e) =>
-          setActionsAnchorEl((prev) => (prev ? null : e.currentTarget))
-        }
-      >
-        <IconMoreVert />
-      </TooltipIconButton>
-
-      <Menu
-        id={menuId}
-        anchorEl={actionsAnchorEl}
-        open={actionsOpen}
-        onClick={onCloseActions}
-        onClose={onCloseActions}
-      >
+      <ActionsMenu title="Beta Actions">
         <MenuItem onClick={() => onCopy(beta.id)}>
           <ListItemIcon>
             <IconContentCopy />
@@ -127,7 +101,7 @@ const BetaListItem: React.FC<Props> = ({
           </ListItemIcon>
           <ListItemText>Delete</ListItemText>
         </MenuItem>
-      </Menu>
+      </ActionsMenu>
     </ListItem>
   );
 };

--- a/ui/src/components/Home/ProblemCard.tsx
+++ b/ui/src/components/Home/ProblemCard.tsx
@@ -13,22 +13,12 @@ import { ProblemCard_problemNode$key } from "./__generated__/ProblemCard_problem
 import LinkBehavior from "components/common/LinkBehavior";
 import { isDefined } from "util/func";
 import TooltipIconButton from "components/common/TooltipIconButton";
-import { validateExternalLink } from "util/validator";
 import ExternalProblemLink from "components/common/ExternalProblemLink";
-import Editable from "components/common/Editable";
 
 const dateFormat = new Intl.DateTimeFormat(undefined, { dateStyle: "long" });
 
 interface Props {
   problemKey: ProblemCard_problemNode$key;
-  /**
-   * Called to save changes to metadata. Only provided fields will be modified.
-   */
-  onSaveChanges?: (args: {
-    problemId: string;
-    name?: string;
-    externalLink?: string;
-  }) => void;
   /**
    * Called to delete, *after* confirmation dialog
    */
@@ -37,7 +27,7 @@ interface Props {
 
 const ProblemCard: React.FC<Props> = ({
   problemKey,
-  onSaveChanges,
+
   onDelete,
 }) => {
   const problem = useFragment(
@@ -93,40 +83,14 @@ const ProblemCard: React.FC<Props> = ({
 
       <CardContent>
         <Typography variant="h6" component="h3">
-          {isDefined(problem.name) ? (
-            <Editable
-              value={problem.name}
-              placeholder="Problem Name"
-              onChange={
-                onSaveChanges &&
-                ((newValue) =>
-                  onSaveChanges({ problemId: problem.id, name: newValue }))
-              }
-            />
-          ) : (
-            // Missing value indicates it's still loading
-            <Skeleton />
-          )}
+          {/* Nullish value indicates it's still loading */}
+          {problem.name ?? <Skeleton />}
         </Typography>
 
+        {/* Nullish value indicates it's still loading */}
         {isDefined(problem.externalLink) ? (
-          <Editable
-            value={problem.externalLink}
-            placeholder="External Link"
-            validator={validateExternalLink}
-            onChange={
-              onSaveChanges &&
-              ((newValue) =>
-                onSaveChanges({
-                  problemId: problem.id,
-                  externalLink: newValue,
-                }))
-            }
-          >
-            <ExternalProblemLink />
-          </Editable>
+          <ExternalProblemLink>{problem.externalLink}</ExternalProblemLink>
         ) : (
-          // Missing value indicates it's still loading
           <Skeleton />
         )}
 

--- a/ui/src/components/Home/ProblemList.tsx
+++ b/ui/src/components/Home/ProblemList.tsx
@@ -4,7 +4,6 @@ import ProblemCard from "./ProblemCard";
 import BoulderImageUpload from "./BoulderImageUpload";
 import { ProblemList_query$key } from "./__generated__/ProblemList_query.graphql";
 import { ProblemList_deleteProblemMutation } from "./__generated__/ProblemList_deleteProblemMutation.graphql";
-import { ProblemList_updateProblemMutation } from "./__generated__/ProblemList_updateProblemMutation.graphql";
 import { ProblemList_createBoulderWithFriendsMutation } from "./__generated__/ProblemList_createBoulderWithFriendsMutation.graphql";
 import useMutation from "util/useMutation";
 import MutationErrorSnackbar from "components/common/MutationErrorSnackbar";
@@ -61,20 +60,6 @@ const ProblemList: React.FC<Props> = ({ queryKey }) => {
           }
           beta {
             id
-          }
-        }
-      }
-    `);
-  const { commit: updateProblem, state: updateState } =
-    useMutation<ProblemList_updateProblemMutation>(graphql`
-      mutation ProblemList_updateProblemMutation(
-        $input: UpdateProblemMutationInput!
-      ) {
-        updateProblem(input: $input) {
-          problem {
-            id
-            name
-            externalLink
           }
         }
       }
@@ -148,16 +133,6 @@ const ProblemList: React.FC<Props> = ({ queryKey }) => {
         <ProblemListGridItem key={node.id}>
           <ProblemCard
             problemKey={node}
-            onSaveChanges={({ problemId, name, externalLink }) =>
-              updateProblem({
-                variables: { input: { problemId, name, externalLink } },
-                optimisticResponse: {
-                  updateProblem: {
-                    problem: { id: problemId, name, externalLink },
-                  },
-                },
-              })
-            }
             onDelete={(problemId) =>
               deleteProblem({
                 variables: {
@@ -186,10 +161,6 @@ const ProblemList: React.FC<Props> = ({ queryKey }) => {
       <MutationErrorSnackbar
         message="Error uploading problem"
         state={createState}
-      />
-      <MutationErrorSnackbar
-        message="Error updating problem"
-        state={updateState}
       />
       <MutationErrorSnackbar
         message="Error deleting problem"

--- a/ui/src/components/common/ActionsMenu.tsx
+++ b/ui/src/components/common/ActionsMenu.tsx
@@ -1,0 +1,54 @@
+import { useId, useState } from "react";
+import { Menu } from "@mui/material";
+import { MoreVert as IconMoreVert } from "@mui/icons-material";
+import TooltipIconButton from "./TooltipIconButton";
+
+interface Props {
+  title: string;
+  icon?: React.ReactElement;
+  children?: React.ReactNode;
+}
+
+/**
+ * A popup menu with actions in it. Children should all be <MenuItem>s
+ */
+const ActionsMenu: React.FC<Props> = ({
+  title,
+  icon = <IconMoreVert />,
+  children,
+}) => {
+  const [menuAnchorElement, setMenuAnchorElement] =
+    useState<HTMLElement | null>(null);
+  const actionsOpen = Boolean(menuAnchorElement);
+  const menuId = useId();
+
+  const onClose = (): void => setMenuAnchorElement(null);
+
+  return (
+    <>
+      <TooltipIconButton
+        title={title}
+        aria-controls={actionsOpen ? menuId : undefined}
+        aria-haspopup
+        aria-expanded={actionsOpen}
+        onClick={(e) =>
+          setMenuAnchorElement((prev) => (prev ? null : e.currentTarget))
+        }
+      >
+        {icon}
+      </TooltipIconButton>
+
+      <Menu
+        id={menuId}
+        anchorEl={menuAnchorElement}
+        open={actionsOpen}
+        onClick={onClose}
+        onClose={onClose}
+      >
+        {children}
+      </Menu>
+    </>
+  );
+};
+
+export default ActionsMenu;


### PR DESCRIPTION
Editability within the problem card looks kinda wonky and isn't necessary since those actions are available on the problem page. It feels more natural there anyway. This cleans up the home screen a bit.

I'd like to move the delete button over as well so we can make the whole problem card clickable, but the handling of the delete there is a little delicate because it invalidates the page and requires a redirect, which leads to some fuckiness with the Relay store. A problem for another day.