### PR TITLE
Dedupe guest accounts when re-logging in 

### DIFF
--- a/api/src/beta_spray/settings/settings.py
+++ b/api/src/beta_spray/settings/settings.py
@@ -65,8 +65,10 @@ SOCIAL_AUTH_JSONFIELD_ENABLED = True
 SOCIAL_AUTH_PIPELINE = (
     "social_core.pipeline.social_auth.social_details",
     "social_core.pipeline.social_auth.social_uid",
-    "social_core.pipeline.social_auth.social_user",
     "social_core.pipeline.social_auth.auth_allowed",
+    "core.pipeline.find_existing_user",
+    # This doesn't do anything currently since we only allow one provider, but
+    # eventually it may be helpful
     "social_core.pipeline.social_auth.associate_by_email",
     "social_core.pipeline.user.create_user",
     "social_core.pipeline.social_auth.associate_user",

--- a/api/src/core/pipeline.py
+++ b/api/src/core/pipeline.py
@@ -1,7 +1,51 @@
 from typing import Any
 
 from django.contrib.auth.models import User
-from guest_user.functions import get_guest_model
+from guest_user.functions import get_guest_model, is_guest_user
+from social_core.backends.base import BaseAuth
+from social_core.exceptions import AuthAlreadyAssociated
+
+from core.models import Beta, Problem
+
+
+def find_existing_user(
+    backend: BaseAuth, uid: str, user: User = None, *args: Any, **kwargs: Any
+) -> dict:
+    """
+    A copy of the stock social_user pipeline, modified to allow linking guest
+    users to existing users.
+    """
+    provider = backend.name
+    social = backend.strategy.storage.user.get_social_auth(provider, uid)
+    if social:
+        if user and social.user != user:
+            if is_guest_user(user):
+                # Link the guest into the existing user. THe guest user may
+                # own some objects, so we need to update those to point to the
+                # new owner. We'll have to add to this list any time we add
+                # `owner` columns, which kinda sucks
+                Problem.objects.filter(owner=user).update(owner=social.user)
+                Beta.objects.filter(owner=user).update(owner=social.user)
+
+                user.delete()
+                user = social.user
+                # TODO this doesn't reassign the request session, so the user
+                # isn't logged in at the end of the request. Fix this.
+            else:
+                # This *shouldn't* happen, because it implies was already
+                # logged in under a regular account, then tried to log in again.
+                # The login screen should only be visible if the user is
+                # unauthenticated or a guest
+                raise AuthAlreadyAssociated(backend)
+        elif not user:
+            # User doesn't exist yet
+            user = social.user
+    return {
+        "social": social,
+        "user": user,
+        "is_new": user is None,
+        "new_association": social is None,
+    }
 
 
 def convert_guest_user(user: User, *args: Any, **kwargs: Any) -> None:

--- a/ui/src/components/Account/AccountMenu.tsx
+++ b/ui/src/components/Account/AccountMenu.tsx
@@ -79,6 +79,8 @@ const AccountMenu: React.FC<Props> = ({ userKey }) => {
     );
   }
 
+  const { isGuest } = currentUser;
+
   // Logged In
   return (
     <>
@@ -86,7 +88,7 @@ const AccountMenu: React.FC<Props> = ({ userKey }) => {
         <ListItem>{currentUser.username}</ListItem>
         <Divider />
 
-        {currentUser.isGuest && (
+        {isGuest && (
           <MenuItem component={Link} href="/login">
             <ListItemIcon>
               <IconLogin />
@@ -95,28 +97,31 @@ const AccountMenu: React.FC<Props> = ({ userKey }) => {
           </MenuItem>
         )}
 
-        <MenuItem onClick={() => setIsSettingsOpen(true)}>
+        <MenuItem disabled={isGuest} onClick={() => setIsSettingsOpen(true)}>
           <ListItemIcon>
             <IconSettings />
           </ListItemIcon>
           <ListItemText>Settings</ListItemText>
         </MenuItem>
-        <MenuItem
-          onClick={() =>
-            logOut({
-              variables: {},
-              onCompleted() {
-                // Reload the page, since a lot of content can change
-                navigate(0);
-              },
-            })
-          }
-        >
-          <ListItemIcon>
-            <IconLogout />
-          </ListItemIcon>
-          <ListItemText>Log out</ListItemText>
-        </MenuItem>
+
+        {!isGuest && (
+          <MenuItem
+            onClick={() =>
+              logOut({
+                variables: {},
+                onCompleted() {
+                  // Reload the page, since a lot of content can change
+                  navigate(0);
+                },
+              })
+            }
+          >
+            <ListItemIcon>
+              <IconLogout />
+            </ListItemIcon>
+            <ListItemText>Log out</ListItemText>
+          </MenuItem>
+        )}
       </ActionsMenu>
 
       <AccountSettings


### PR DESCRIPTION
- User logs in w/ Google
- In another browser (or session timed out, or logged out, etc.), user makes another mutation, creating a new guest user
- User logs in to their existing Google account

Previously, this would error. Now it merges the new guest account into the existing Google account. There is still one thing broken on this though: after the new login process, the session doesn't get updated on the request so the user will be logged out again. They can just log in again to the Google account. It's shitty but better than it was before at least.