### PR TITLE
Add popup dialog to warn guest users about potential for data loss

### DIFF
--- a/ui/src/components/Account/AccountMenu.tsx
+++ b/ui/src/components/Account/AccountMenu.tsx
@@ -24,12 +24,12 @@ import useMutation from "util/useMutation";
 import { queriesCurrentUserQuery } from "util/__generated__/queriesCurrentUserQuery.graphql";
 import AccountSettings from "./AccountSettings";
 import { AccountMenu_logOutMutation } from "./__generated__/AccountMenu_logOutMutation.graphql";
-import { AccountMenu_userNode$key } from "./__generated__/AccountMenu_userNode.graphql";
-import { UserQueryContext, useLoginPath } from "util/user";
+import { AccountMenu_currentUser$key } from "./__generated__/AccountMenu_currentUser.graphql";
+import { UserQueryContext, useLogInPath } from "util/user";
 import Username from "./Username";
 
 interface Props {
-  userKey: AccountMenu_userNode$key;
+  currentUserKey: AccountMenu_currentUser$key;
 }
 
 /**
@@ -39,12 +39,12 @@ interface Props {
  * - Guest account (new user who's performed a mutation)
  * - Authenticated user (they went through the sign in process)
  */
-const AccountMenu: React.FC<Props> = ({ userKey }) => {
+const AccountMenu: React.FC<Props> = ({ currentUserKey }) => {
   // Lazy loading is fine here, since this should be part of the first render
   // of every page
   const currentUser = useFragment(
     graphql`
-      fragment AccountMenu_userNode on UserNodeNoUser {
+      fragment AccountMenu_currentUser on UserNodeNoUser {
         # There's a NoUser variant to indicate not logged in. Intuitively we
         # could just make this nullable, but then it's not possible to invalidate
         # this from an updater, which we want to do from any mutation, to trigger
@@ -58,7 +58,7 @@ const AccountMenu: React.FC<Props> = ({ userKey }) => {
         }
       }
     `,
-    userKey
+    currentUserKey
   );
 
   const { commit: logOut, state: logOutState } =
@@ -68,13 +68,13 @@ const AccountMenu: React.FC<Props> = ({ userKey }) => {
       }
     `);
 
-  const loginPath = useLoginPath();
+  const logInPath = useLogInPath();
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
 
   // Logged Out
   if (currentUser.__typename !== "UserNode") {
     return (
-      <Button component={Link} href={loginPath}>
+      <Button component={Link} href={logInPath}>
         Log in
       </Button>
     );
@@ -92,7 +92,7 @@ const AccountMenu: React.FC<Props> = ({ userKey }) => {
         <Divider />
 
         {isGuest && (
-          <MenuItem component={Link} href={loginPath}>
+          <MenuItem component={Link} href={logInPath}>
             <ListItemIcon>
               <IconLogin />
             </ListItemIcon>
@@ -144,6 +144,6 @@ const AccountMenu: React.FC<Props> = ({ userKey }) => {
 export default withContextQuery<queriesCurrentUserQuery, Props>({
   context: UserQueryContext,
   query: currentUserQuery,
-  dataToProps: (data) => ({ userKey: data.currentUser }),
+  dataToProps: (data) => ({ currentUserKey: data.currentUser }),
   fallbackElement: <Loading />,
 })(AccountMenu);

--- a/ui/src/components/Account/GuestUserWarningDialog.tsx
+++ b/ui/src/components/Account/GuestUserWarningDialog.tsx
@@ -1,0 +1,99 @@
+import { graphql, useFragment } from "react-relay";
+import { GuestUserWarningDialog_currentUser$key } from "./__generated__/GuestUserWarningDialog_currentUser.graphql";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Link,
+} from "@mui/material";
+import { queriesCurrentUserQuery } from "util/__generated__/queriesCurrentUserQuery.graphql";
+import { UserQueryContext, useLogInPath } from "util/user";
+import { withContextQuery } from "relay-query-wrapper";
+import { currentUserQuery } from "util/queries";
+import { useEffect, useState } from "react";
+import GuestUserWarningText from "./GuestUserWarningText";
+
+const storageKey = "guestUserWarning";
+const storageValueHide = "hide";
+
+interface Props {
+  currentUserKey: GuestUserWarningDialog_currentUser$key;
+}
+
+/**
+ * A dialog that warns guest users of their potential for data loss. Appears
+ * the first time the site renders as a guest user, at which point it should
+ * be hidden for the rest of the session.
+ */
+const GuestUserWarningDialog: React.FC<Props> = ({ currentUserKey }) => {
+  const currentUser = useFragment(
+    graphql`
+      fragment GuestUserWarningDialog_currentUser on UserNodeNoUser {
+        ... on UserNode {
+          isGuest
+        }
+      }
+    `,
+    currentUserKey
+  );
+
+  const logInPath = useLogInPath();
+  const [isOpen, setIsOpen] = useState(false);
+
+  // Open the dialog the first time we see a guest user
+  const isGuest = Boolean(currentUser?.isGuest);
+  useEffect(() => {
+    // Check session storage to make sure we're not annoying about it. We might
+    // want to replace this with localStorage, just a matter of finding the
+    // right level of annoying.
+    if (isGuest && sessionStorage.getItem(storageKey) !== storageValueHide) {
+      setIsOpen(true);
+    }
+    if (!isGuest) {
+      sessionStorage.removeItem(storageKey);
+    }
+  }, [isGuest]);
+
+  if (!currentUser?.isGuest) {
+    return null;
+  }
+
+  const onClose = (): void => {
+    setIsOpen(false);
+    sessionStorage.setItem(storageKey, storageValueHide);
+  };
+
+  return (
+    <Dialog open={isOpen} fullWidth onClose={onClose}>
+      <DialogTitle>Logged In as Guest</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          <GuestUserWarningText />
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Continue as Guest</Button>
+        <Button
+          variant="contained"
+          component={Link}
+          href={logInPath}
+          onClick={onClose}
+          // DialogActions doesn't apply proper margin to links
+          sx={{ marginLeft: 1 }}
+        >
+          Log In
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default withContextQuery<queriesCurrentUserQuery, Props>({
+  context: UserQueryContext,
+  query: currentUserQuery,
+  dataToProps: (data) => ({ currentUserKey: data.currentUser }),
+  fallbackElement: null,
+})(GuestUserWarningDialog);

--- a/ui/src/components/Account/GuestUserWarningText.tsx
+++ b/ui/src/components/Account/GuestUserWarningText.tsx
@@ -1,0 +1,22 @@
+import { Link } from "@mui/material";
+import { useLogInPath } from "util/user";
+
+/**
+ * Friendly little text blob warning user that their shit could get lost.
+ */
+const GuestUserWarningText: React.FC = () => {
+  const logInPath = useLogInPath();
+  return (
+    <>
+      You are logged in as a guest. Any content (problems, beta, etc.) you share
+      will be saved, but you won't be able to edit it from any other device, and
+      sharing options are limited. If you ever lose access to this guest
+      account, <b>you will not be able to edit your content</b>. To secure
+      permanent access to your content, <Link href={logInPath}>log in</Link>. No
+      password required, and all your content will be transferred to your new
+      account.
+    </>
+  );
+};
+
+export default GuestUserWarningText;

--- a/ui/src/components/Account/LogInPage.tsx
+++ b/ui/src/components/Account/LogInPage.tsx
@@ -6,18 +6,18 @@ import { Navigate, useSearchParams } from "react-router-dom";
 import { withContextQuery } from "relay-query-wrapper";
 import { currentUserQuery } from "util/queries";
 import { queriesCurrentUserQuery } from "util/__generated__/queriesCurrentUserQuery.graphql";
-import { LogInPage_userNode$key } from "./__generated__/LogInPage_userNode.graphql";
+import { LogInPage_currentUser$key } from "./__generated__/LogInPage_currentUser.graphql";
 import { UserQueryContext } from "util/user";
 
 interface Props {
-  userKey: LogInPage_userNode$key;
+  currentUserKey: LogInPage_currentUser$key;
 }
 
-const LogInPage: React.FC<Props> = ({ userKey }) => {
+const LogInPage: React.FC<Props> = ({ currentUserKey }) => {
   // TODO implement support for ?next= param on this page
   const currentUser = useFragment(
     graphql`
-      fragment LogInPage_userNode on UserNodeNoUser {
+      fragment LogInPage_currentUser on UserNodeNoUser {
         # There's a NoUser variant to indicate not logged in. Intuitively we
         # could just make this nullable, but then it's not possible to invalidate
         # this from an updater, which we want to do from any mutation, to trigger
@@ -28,7 +28,7 @@ const LogInPage: React.FC<Props> = ({ userKey }) => {
         }
       }
     `,
-    userKey
+    currentUserKey
   );
 
   // If we were given a ?next= param, forward that to the API. It will make sure
@@ -75,6 +75,6 @@ const LogInPage: React.FC<Props> = ({ userKey }) => {
 export default withContextQuery<queriesCurrentUserQuery, Props>({
   context: UserQueryContext,
   query: currentUserQuery,
-  dataToProps: (data) => ({ userKey: data.currentUser }),
+  dataToProps: (data) => ({ currentUserKey: data.currentUser }),
   fallbackElement: <Loading />,
 })(LogInPage);

--- a/ui/src/components/Account/Username.tsx
+++ b/ui/src/components/Account/Username.tsx
@@ -1,8 +1,9 @@
-import { Box, IconProps, Link, Skeleton } from "@mui/material";
+import { Box, IconProps, Skeleton } from "@mui/material";
 import { graphql, useFragment } from "react-relay";
 import { Username_userNode$key } from "./__generated__/Username_userNode.graphql";
 import HelpAnnotated from "components/common/HelpAnnotated";
 import { Person as IconPerson } from "@mui/icons-material";
+import GuestUserWarningText from "./GuestUserWarningText";
 
 interface Props {
   userKey: Username_userNode$key;
@@ -38,19 +39,7 @@ const Username: React.FC<Props> = ({ userKey, iconSize }) => {
   // For guest users, show a tooltip explaining the situation.
   if (user.isCurrentUser && user.isGuest) {
     return (
-      <HelpAnnotated
-        helpText={
-          <>
-            You are logged in as a guest. Any content (problems, beta, etc.) you
-            share will be saved, but you won't be able to edit it from any other
-            device, and sharing options are limited. If you ever lose access to
-            this guest account, <b>you will not be able to edit your content</b>
-            . To secure permanent access to your content,{" "}
-            <Link href="/login">log in</Link>. All your content will be
-            transferred to your new account.
-          </>
-        }
-      >
+      <HelpAnnotated helpText={<GuestUserWarningText />}>
         {content}
       </HelpAnnotated>
     );

--- a/ui/src/components/CoreContent.tsx
+++ b/ui/src/components/CoreContent.tsx
@@ -15,6 +15,7 @@ import AboutPage from "./AboutPage";
 import TextLayout from "./PageLayout/TextLayout";
 import LogInPage from "./Account/LogInPage";
 import UserQueryProvider from "./UserQueryProvider";
+import GuestUserWarningDialog from "./Account/GuestUserWarningDialog";
 
 // Code splitting!
 const HomePage = React.lazy(
@@ -49,6 +50,9 @@ const CoreContent: React.FC = () => (
           <Suspense fallback={<Loading size={100} height="100vh" />}>
             <ErrorBoundary>
               <UserQueryProvider>
+                {/* This dialog can appear on any page */}
+                <GuestUserWarningDialog />
+
                 <Routes>
                   {/* Fullscreen routes */}
                   <Route path={"problems/:problemId"} element={<EditorPage />}>

--- a/ui/src/util/queries.ts
+++ b/ui/src/util/queries.ts
@@ -16,9 +16,10 @@ import { graphql } from "react-relay";
 export const currentUserQuery = graphql`
   query queriesCurrentUserQuery {
     currentUser {
-      ...AccountMenu_userNode
-      ...LogInPage_userNode
-      ...userUseOptimisiticUserFields_userNode
+      ...AccountMenu_currentUser
+      ...LogInPage_currentUser
+      ...GuestUserWarningDialog_currentUser
+      ...userUseOptimisiticUserFields_currentUser
     }
   }
 `;

--- a/ui/src/util/user.ts
+++ b/ui/src/util/user.ts
@@ -12,7 +12,7 @@ import {
 } from "relay-runtime";
 import type { queriesCurrentUserQuery as queriesCurrentUserQueryType } from "util/__generated__/queriesCurrentUserQuery.graphql";
 import { currentUserQuery } from "./queries";
-import { userUseOptimisiticUserFields_userNode$key } from "./__generated__/userUseOptimisiticUserFields_userNode.graphql";
+import { userUseOptimisiticUserFields_currentUser$key } from "./__generated__/userUseOptimisiticUserFields_currentUser.graphql";
 import { useLocation } from "react-router-dom";
 
 interface UserQuery {
@@ -50,9 +50,9 @@ export function useOptimisiticUserFields(): {
   const { queryRef } = useContext(UserQueryContext);
   // Unpack the data from the query ref, then into a fragment
   const data = usePreloadedQuery(currentUserQuery, queryRef);
-  const currentUser = useFragment<userUseOptimisiticUserFields_userNode$key>(
+  const currentUser = useFragment<userUseOptimisiticUserFields_currentUser$key>(
     graphql`
-      fragment userUseOptimisiticUserFields_userNode on UserNodeNoUser {
+      fragment userUseOptimisiticUserFields_currentUser on UserNodeNoUser {
         __typename
         ... on UserNode {
           id
@@ -85,7 +85,7 @@ export function useOptimisiticUserFields(): {
  * Get a path for links to the login page. This will include a query param on
  * the path to make sure we return to the current page after login
  */
-export function useLoginPath(): string {
+export function useLogInPath(): string {
   const location = useLocation();
   // Maintain path+query+hash. We can't retain router state since that's in-memory only.
   // This doesn't seem to work entirely in firefox because it preemptively


### PR DESCRIPTION
It will appear on first render if the user is a guest, which means initial page load if they're already signed in as a guest, or immediately after performing a mutation, when the guest user is created. TBD if this is too annoying.

![image](https://user-images.githubusercontent.com/2382935/227802121-f50f4776-0b72-4791-af76-ca87f9b3bcf4.png)
