### PR TITLE
Better beta editability

### DIFF
--- a/ui/src/components/Editor/EditorSvg/BetaEditor/BetaChainLine.tsx
+++ b/ui/src/components/Editor/EditorSvg/BetaEditor/BetaChainLine.tsx
@@ -6,6 +6,7 @@ import {
   useBetaMoveColor,
   useBetaMoveVisualPosition,
 } from "components/Editor/util/moves";
+import { getEditableFilterUrl } from "../EditableFilter";
 
 interface Props {
   startMoveKey: BetaChainLine_startBetaMoveNode$key;
@@ -64,6 +65,7 @@ const BetaChainLine: React.FC<Props> = ({ startMoveKey, endMoveKey }) => {
       </defs>
       <line
         css={{ strokeWidth: 0.5 }}
+        filter={getEditableFilterUrl("beta")} // Color based on editability
         stroke={`url(#${gradientId})`}
         strokeDasharray="1.5 1"
         {...coords}

--- a/ui/src/components/Editor/EditorSvg/BetaEditor/BetaEditor.tsx
+++ b/ui/src/components/Editor/EditorSvg/BetaEditor/BetaEditor.tsx
@@ -19,6 +19,7 @@ import {
 } from "components/Editor/util/moves";
 import useBetaMoveMutations from "components/Editor/util/useBetaMoveMutations";
 import EditAnnotationDialog from "../EditAnnotationDialog";
+import EditableFilter from "../EditableFilter";
 
 interface Props {
   betaKey: BetaEditor_betaNode$key;
@@ -135,6 +136,10 @@ const BetaEditor: React.FC<Props> = ({ betaKey }) => {
           ) : null;
         })
       )}
+
+      {/* This filter lets us easily modify the visuals of all beta editor
+          components, based on current edit mode */}
+      <EditableFilter kind="beta" isEditing={isEditing} />
 
       {/* Render body position. This will only show something if the user is
           hovering a move. We want this above the move lines, but below the

--- a/ui/src/components/Editor/EditorSvg/BetaEditor/BetaMoveIcon.tsx
+++ b/ui/src/components/Editor/EditorSvg/BetaEditor/BetaMoveIcon.tsx
@@ -8,7 +8,8 @@ import {
 } from "styles/svg";
 import { Interpolation, Theme } from "@emotion/react";
 import { isDefined } from "util/func";
-import { SvgIcon, SvgIconProps, useTheme } from "@mui/material";
+import { SvgIcon, SvgIconProps } from "@mui/material";
+import { getEditableFilterUrl } from "../EditableFilter";
 
 interface Props {
   bodyPart: BodyPart;
@@ -49,58 +50,62 @@ const BetaMoveIcon = React.forwardRef<
       ...rest
     },
     ref
-  ) => {
-    const { palette } = useTheme();
-    return (
-      <g
-        ref={ref}
-        css={[
-          { stroke: "#00000000" },
-          // Draggable should override clickable
-          clickable && styleClickable,
-          draggable && styleDraggable,
-          isDragging && styleDragging,
-          isHighlighted && styleHighlight,
-          parentCss,
-        ]}
-        {...rest}
-      >
-        {/* We need this wrapper so we don't fuck up the transform that the
+  ) => (
+    <g
+      ref={ref}
+      css={[
+        { stroke: "#00000000" },
+        // Draggable should override clickable
+        clickable && styleClickable,
+        draggable && styleDraggable,
+        isDragging && styleDragging,
+        isHighlighted && styleHighlight,
+        parentCss,
+      ]}
+      {...rest}
+    >
+      {/* We need this wrapper so we don't fuck up the transform that the
             icon does on itself.*/}
-        <g css={{ transform: `scale(${variant === "large" ? 1.5 : 0.75})` }}>
-          <IconBodyPartRaw
-            bodyPart={bodyPart}
-            css={[
-              color && { fill: color },
-              // Free moves get a dotted outline. This has to go *before* the
-              // isStart rule, because that one should always take priority
-              // for stroke color
-              isFree && { stroke: "white", strokeDasharray: "1,0.5" },
-              isStart && { stroke: palette.secondary.main },
-            ]}
-          />
-        </g>
-
-        {isDefined(order) && variant === "large" && (
-          <text
-            css={{
-              fontSize: 4,
-              userSelect: "none",
-              pointerEvents: "none",
-              // This should contrast all possible fill colors
-              color: "black",
-            }}
-            textAnchor="middle"
-            dominantBaseline="middle"
-          >
-            {order}
-          </text>
-        )}
-
-        {children}
+      <g
+        filter={getEditableFilterUrl("beta")} // Color based on editability
+        css={{ transform: `scale(${variant === "large" ? 1.5 : 0.75})` }}
+      >
+        <IconBodyPartRaw
+          bodyPart={bodyPart}
+          css={({ palette }) => [
+            color && { fill: color },
+            // Free moves get a dotted outline. This has to go *before* the
+            // isStart rule, because that one should always take priority
+            // for stroke color
+            isFree && { stroke: "white", strokeDasharray: "1,0.5" },
+            isStart && {
+              stroke: draggable
+                ? palette.secondary.main
+                : palette.secondary.light,
+            },
+          ]}
+        />
       </g>
-    );
-  }
+
+      {isDefined(order) && variant === "large" && (
+        <text
+          css={{
+            fontSize: 4,
+            userSelect: "none",
+            pointerEvents: "none",
+            // This should contrast all possible fill colors
+            color: "black",
+          }}
+          textAnchor="middle"
+          dominantBaseline="middle"
+        >
+          {order}
+        </text>
+      )}
+
+      {children}
+    </g>
+  )
 );
 
 BetaMoveIcon.displayName = "BetaMoveIcon";

--- a/ui/src/components/Editor/EditorSvg/BetaEditor/BetaMoveIcon.tsx
+++ b/ui/src/components/Editor/EditorSvg/BetaEditor/BetaMoveIcon.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import { BodyPart } from "components/Editor/util/svg";
-import { styleDraggable, styleHighlight, styleDragging } from "styles/svg";
+import {
+  styleDraggable,
+  styleHighlight,
+  styleDragging,
+  styleClickable,
+} from "styles/svg";
 import { Interpolation, Theme } from "@emotion/react";
 import { isDefined } from "util/func";
 import { SvgIcon, SvgIconProps, useTheme } from "@mui/material";
@@ -12,6 +17,7 @@ interface Props {
   variant?: "small" | "large";
   isFree?: boolean;
   isStart?: boolean;
+  clickable?: boolean;
   draggable?: boolean;
   isDragging?: boolean;
   isHighlighted?: boolean;
@@ -34,6 +40,7 @@ const BetaMoveIcon = React.forwardRef<
       variant = "large",
       isFree = false,
       isStart = false,
+      clickable = false,
       draggable = false,
       isDragging = false,
       isHighlighted = false,
@@ -47,11 +54,13 @@ const BetaMoveIcon = React.forwardRef<
     return (
       <g
         ref={ref}
-        css={(theme) => [
+        css={[
           { stroke: "#00000000" },
+          // Draggable should override clickable
+          clickable && styleClickable,
           draggable && styleDraggable,
-          isDragging && styleDragging(theme),
-          isHighlighted && styleHighlight(theme),
+          isDragging && styleDragging,
+          isHighlighted && styleHighlight,
           parentCss,
         ]}
         {...rest}

--- a/ui/src/components/Editor/EditorSvg/BetaEditor/BetaMoveMark.tsx
+++ b/ui/src/components/Editor/EditorSvg/BetaEditor/BetaMoveMark.tsx
@@ -35,7 +35,7 @@ interface Props {
 const BetaMoveMark: React.FC<Props> = ({
   betaMoveKey,
   isInCurrentStance,
-  editable,
+  editable = false,
   onEditAnnotation,
   onDelete,
   onDragFinish,
@@ -110,18 +110,17 @@ const BetaMoveMark: React.FC<Props> = ({
             isFree={!isDefined(betaMove.hold)}
             color={color}
             variant={isInCurrentStance || isHighlighted ? "large" : "small"}
+            clickable // Move can be highlighted, even when not editing
             draggable={editable}
             isDragging={isDragging}
             isHighlighted={isHighlighted}
             // Don't block drop events when another element is being dragged
             css={isDraggingOther && { pointerEvents: "none" }}
             // Click => toggle highlight
-            onClick={
-              editable ? () => setIsHighlighted((prev) => !prev) : undefined
-            }
+            onClick={() => setIsHighlighted((prev) => !prev)}
           />
 
-          <ActionOrbs open={isHighlighted}>
+          <ActionOrbs open={editable && isHighlighted}>
             <ActionOrb
               color={palette.editorActionDelete.main}
               onClick={onDelete && (() => onDelete(betaMove.id))}

--- a/ui/src/components/Editor/EditorSvg/BetaEditor/StickFigure.tsx
+++ b/ui/src/components/Editor/EditorSvg/BetaEditor/StickFigure.tsx
@@ -17,6 +17,7 @@ import { DragFinishHandler } from "components/Editor/util/dnd";
 import { useBetaMoveVisualPosition } from "components/Editor/util/moves";
 import AddBetaMoveMark from "./AddBetaMoveMark";
 import Positioned from "../common/Positioned";
+import { getEditableFilterUrl } from "../EditableFilter";
 
 /**
  * The torso will always be this percentage of the distance between hands and
@@ -81,7 +82,12 @@ const StickFigure: React.FC<Props> = ({
     { bodyPart: "RIGHT_FOOT", joint: hips },
   ];
   return (
-    <g strokeWidth={1} stroke={color} fill="none">
+    <g
+      strokeWidth={1}
+      stroke={color}
+      fill="none"
+      filter={getEditableFilterUrl("beta")} // Color based on editability
+    >
       {/* Head */}
       <circle r={headRadius} cx={head.x} cy={head.y} />
       {/* Torso */}

--- a/ui/src/components/Editor/EditorSvg/EditableFilter.tsx
+++ b/ui/src/components/Editor/EditorSvg/EditableFilter.tsx
@@ -1,0 +1,32 @@
+interface Props {
+  kind: "hold" | "beta";
+  isEditing: boolean;
+}
+
+/**
+ * A visual SVG filter that indicates an item is/isn't editable.
+ */
+const EditableFilter: React.FC<Props> = ({ kind, isEditing }) => (
+  <filter id={getEditableFilterId(kind)} filterUnits="objectBoundingBox">
+    <feColorMatrix
+      type="saturate"
+      in="SourceGraphic"
+      // TODO put this value in the theme
+      values={isEditing ? "1.0" : "0.4"}
+    />
+  </filter>
+);
+
+function getEditableFilterId(kind: Props["kind"]): string {
+  return `${kind}-editable-filter`;
+}
+
+/**
+ * Get an SVG URL of an editable filter.
+ * @returns A string that can be passed to the filter= attribute of an element
+ */
+export function getEditableFilterUrl(kind: Props["kind"]): string {
+  return `url(#${getEditableFilterId(kind)})`;
+}
+
+export default EditableFilter;

--- a/ui/src/components/Editor/EditorSvg/HoldEditor/HoldEditor.tsx
+++ b/ui/src/components/Editor/EditorSvg/HoldEditor/HoldEditor.tsx
@@ -15,6 +15,7 @@ import { HoldEditor_updateHoldPositionMutation } from "./__generated__/HoldEdito
 import { HoldEditor_updateHoldAnnotationMutation } from "./__generated__/HoldEditor_updateHoldAnnotationMutation.graphql";
 import { useDOMToSVGPosition } from "components/Editor/util/svg";
 import { EditorModeContext } from "components/Editor/util/context";
+import EditableFilter from "../EditableFilter";
 
 interface Props {
   problemKey: HoldEditor_problemNode$key;
@@ -137,6 +138,7 @@ const HoldEditor: React.FC<Props> = ({ problemKey }) => {
 
   return (
     <>
+      <EditableFilter kind="hold" isEditing={isEditing} />
       {/* Invisible layer to capture SVG panning, as well as holds/moves
           being dropped and clicks for adding holds. This has to be a child
           here so we can pass the onClick. */}

--- a/ui/src/components/Editor/EditorSvg/HoldEditor/HoldIcon.tsx
+++ b/ui/src/components/Editor/EditorSvg/HoldEditor/HoldIcon.tsx
@@ -1,4 +1,5 @@
 import {
+  styleClickable,
   styleDraggable,
   styleDragging,
   styleDropHover,
@@ -21,6 +22,7 @@ interface Props extends React.SVGProps<SVGCircleElement> {
  * just the inline SVG element, *without* the wrapping SVG.
  */
 const HoldIcon: React.FC<Props> = ({
+  clickable = false,
   draggable = false,
   isDragging = false,
   isHighlighted = false,
@@ -31,7 +33,7 @@ const HoldIcon: React.FC<Props> = ({
   const { palette } = useTheme();
   return (
     <circle
-      css={(theme) => [
+      css={[
         parentCss,
         {
           r: 3,
@@ -40,11 +42,12 @@ const HoldIcon: React.FC<Props> = ({
           // We want the fill to be present so it captures events, but invisible
           fillOpacity: 0,
         },
+        clickable && styleClickable,
         draggable && { stroke: palette.primary.main },
-        draggable && styleDraggable(theme),
-        isDragging && styleDragging(theme),
-        isHighlighted && styleHighlight(theme),
-        isOver && styleDropHover(theme),
+        draggable && styleDraggable,
+        isDragging && styleDragging,
+        isHighlighted && styleHighlight,
+        isOver && styleDropHover,
       ]}
       {...rest}
     />

--- a/ui/src/components/Editor/EditorSvg/HoldEditor/HoldIcon.tsx
+++ b/ui/src/components/Editor/EditorSvg/HoldEditor/HoldIcon.tsx
@@ -7,6 +7,7 @@ import {
 } from "styles/svg";
 import { Interpolation, Theme } from "@emotion/react";
 import { SvgIcon, SvgIconProps, useTheme } from "@mui/material";
+import { getEditableFilterUrl } from "../EditableFilter";
 
 interface Props extends React.SVGProps<SVGCircleElement> {
   clickable?: boolean;
@@ -33,17 +34,17 @@ const HoldIcon: React.FC<Props> = ({
   const { palette } = useTheme();
   return (
     <circle
+      filter={getEditableFilterUrl("hold")} // Color based on editability
       css={[
         parentCss,
         {
           r: 3,
           strokeWidth: 0.5,
-          stroke: palette.grey[300],
+          stroke: palette.primary.main,
           // We want the fill to be present so it captures events, but invisible
           fillOpacity: 0,
         },
         clickable && styleClickable,
-        draggable && { stroke: palette.primary.main },
         draggable && styleDraggable,
         isDragging && styleDragging,
         isHighlighted && styleHighlight,

--- a/ui/src/components/Editor/EditorSvg/HoldEditor/HoldMark.tsx
+++ b/ui/src/components/Editor/EditorSvg/HoldEditor/HoldMark.tsx
@@ -104,17 +104,16 @@ const HoldMark: React.FC<Props> = ({
       <ClickAwayListener onClickAway={() => setIsHighlighted(false)}>
         <Positioned ref={ref} position={hold.position}>
           <HoldIcon
+            clickable // Move can be highlighted, even when not editing
             draggable={editable}
             isDragging={isDragging}
             isOver={isOver}
             isHighlighted={isHighlighted}
             // Click => toggle highlight
-            onClick={
-              editable ? () => setIsHighlighted((prev) => !prev) : undefined
-            }
+            onClick={() => setIsHighlighted((prev) => !prev)}
           />
 
-          <ActionOrbs open={isHighlighted}>
+          <ActionOrbs open={editable && isHighlighted}>
             <ActionOrb
               color={palette.editorActionDelete.main}
               onClick={onDelete && (() => onDelete(hold.id))}

--- a/ui/src/components/Editor/util/stance.ts
+++ b/ui/src/components/Editor/util/stance.ts
@@ -131,14 +131,13 @@ export function useLastMoveInStance(): string | undefined {
 export function useStickFigureColor(stance: Partial<Stance>): string {
   const getBetaMoveColor = useBetaMoveColor();
   const moves = Object.values(stance);
-  if (moves.length === 0) {
-    return "#ffffff";
-  }
-  return hexToHtml(
-    averageColors(
-      moves.map((betaMoveId) => htmlToHex(getBetaMoveColor(betaMoveId)))
-    )
-  );
+  return moves.length === 0
+    ? "#ffffff"
+    : hexToHtml(
+        averageColors(
+          moves.map((betaMoveId) => htmlToHex(getBetaMoveColor(betaMoveId)))
+        )
+      );
 }
 
 /**

--- a/ui/src/styles/svg.ts
+++ b/ui/src/styles/svg.ts
@@ -15,6 +15,11 @@ export type StyleFunction = (theme: Theme) => SerializedStyles;
 export const disambiguationDistance = 4;
 
 /**
+ * Apply to elements that can be clicked
+ */
+export const styleClickable: StyleFunction = () => css({ cursor: "pointer" });
+
+/**
  * Apply to elements that are draggable and currently being hovered or dragged
  */
 export const styleDraggableHover: StyleFunction = () =>


### PR DESCRIPTION
- Make holds and moves highlightable even when not editable
- Desaturate holds and moves when not editable

<img width="617" alt="image" src="https://user-images.githubusercontent.com/2382935/233696385-03fa0f6b-6911-4657-8121-140e95a9204c.png">

<img width="575" alt="image" src="https://user-images.githubusercontent.com/2382935/233696409-b8bd6615-2ead-46ae-bea3-a8ab9ef60bb3.png">

<img width="610" alt="image" src="https://user-images.githubusercontent.com/2382935/233696437-c1f0718c-065e-46dc-9181-e5820dbf2934.png">
