### PR TITLE
Use index for stance state instead of ID

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -33,7 +33,7 @@
         "@babel/preset-typescript": "^7.18.6",
         "@ch1ffa/relay-compiler-webpack-plugin": "^0.3.0",
         "@emotion/babel-plugin": "^11.10.2",
-        "@lucaspickering/eslint-config": "^1.3.0",
+        "@lucaspickering/eslint-config": "^1.4.0",
         "@lucaspickering/tsconfig": "^1.0.0",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
         "@svgr/webpack": "^6.4.0",
@@ -2953,9 +2953,9 @@
       "dev": true
     },
     "node_modules/@lucaspickering/eslint-config": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@lucaspickering/eslint-config/-/eslint-config-1.3.0.tgz",
-      "integrity": "sha512-RspPRcwWgUkgc5Fo3VWjF/y0VYI6Q6AIrqf2bK1O+E/eH+4RisncIHFSsS2FzAIoYSdOHIwED4N4MoVE24gNkg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@lucaspickering/eslint-config/-/eslint-config-1.4.0.tgz",
+      "integrity": "sha512-erX03ff6fx4XYxUjOViETYnxf5bitdHfR622XByQbAmmhgQi7rgGosypK4KnvFQP1p8NUzwQF6BkI1iEBLSaKA==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.37.0",
@@ -15800,9 +15800,9 @@
       "dev": true
     },
     "@lucaspickering/eslint-config": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@lucaspickering/eslint-config/-/eslint-config-1.3.0.tgz",
-      "integrity": "sha512-RspPRcwWgUkgc5Fo3VWjF/y0VYI6Q6AIrqf2bK1O+E/eH+4RisncIHFSsS2FzAIoYSdOHIwED4N4MoVE24gNkg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@lucaspickering/eslint-config/-/eslint-config-1.4.0.tgz",
+      "integrity": "sha512-erX03ff6fx4XYxUjOViETYnxf5bitdHfR622XByQbAmmhgQi7rgGosypK4KnvFQP1p8NUzwQF6BkI1iEBLSaKA==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^5.37.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -29,7 +29,7 @@
     "@babel/preset-typescript": "^7.18.6",
     "@ch1ffa/relay-compiler-webpack-plugin": "^0.3.0",
     "@emotion/babel-plugin": "^11.10.2",
-    "@lucaspickering/eslint-config": "^1.3.0",
+    "@lucaspickering/eslint-config": "^1.4.0",
     "@lucaspickering/tsconfig": "^1.0.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
     "@svgr/webpack": "^6.4.0",

--- a/ui/src/components/Editor/EditorControls/BetaMoveList.tsx
+++ b/ui/src/components/Editor/EditorControls/BetaMoveList.tsx
@@ -206,7 +206,7 @@ const BetaMoveList: React.FC<Props> = ({ betaKey }) => {
           stanceColor={
             stance[node.bodyPart] === node.id ? stickFigureColor : undefined
           }
-          onClick={selectStance}
+          onClick={() => selectStance(node.order)}
           // We need to disable both onReorder and onDrop to get the child to
           // hide its drag handle
           onReorder={canEdit ? onReorder : undefined}

--- a/ui/src/components/Editor/EditorPage.tsx
+++ b/ui/src/components/Editor/EditorPage.tsx
@@ -32,7 +32,7 @@ const EditorPage: React.FC = () => {
   const editorModeState = useState<EditorMode>("beta");
   // Which move denotes the current stick figure stance? This will be the *last*
   // move in the stance
-  const stanceState = useState<string | undefined>();
+  const stanceState = useState<number>(-1);
 
   // Make sure state stays in sync with the URL
   // In most cases we should update both of these simultaneously so this hook

--- a/ui/src/components/Editor/EditorPalette/PlayPauseControls.tsx
+++ b/ui/src/components/Editor/EditorPalette/PlayPauseControls.tsx
@@ -12,6 +12,7 @@ import { graphql, useFragment } from "react-relay";
 import { withQuery } from "relay-query-wrapper";
 import {
   EditorModeContext,
+  EditorSelectedBetaContext,
   EditorVisibilityContext,
 } from "components/Editor/util/context";
 import { alpha, Box, IconButton, Paper } from "@mui/material";
@@ -71,8 +72,15 @@ const PlayPauseControls: React.FC<Props> = ({ betaKey }) => {
     selectLast,
     selectPrevious,
     selectNext,
+    reset,
   } = useStanceControls(beta.moves);
   const [isPlaying, setIsPlaying] = useState<boolean>(false);
+
+  // Reset stance when beta changes
+  const [selectedBeta] = useContext(EditorSelectedBetaContext);
+  useEffect(() => {
+    reset();
+  }, [selectedBeta, reset]);
 
   const pause = (): void => setIsPlaying(false);
 

--- a/ui/src/components/Editor/EditorSvg/BetaEditor/BetaEditor.tsx
+++ b/ui/src/components/Editor/EditorSvg/BetaEditor/BetaEditor.tsx
@@ -79,7 +79,7 @@ const BetaEditor: React.FC<Props> = ({ betaKey }) => {
   const betaMoveVisualPositions = useBetaMoveVisualPositions(beta.moves);
 
   const stance = useStance(beta.moves);
-  const lastStanceMoveId = useLastMoveInStance();
+  const lastStanceMoveId = useLastMoveInStance(beta.moves);
   // The ID of the move whose annotation is being edited
   const [editingBetaMoveId, setEditingBetaMoveId] = useState<string>();
   const editingBetaMove = isDefined(editingBetaMoveId)

--- a/ui/src/components/Editor/util/useBetaMoveMutations.ts
+++ b/ui/src/components/Editor/util/useBetaMoveMutations.ts
@@ -70,6 +70,7 @@ function useBetaMoveMutations(betaKey: useBetaMoveMutations_betaNode$key): {
           # Relay will automatically merge the fields for the new node into the
           # updated connection.
           id
+          order
           # Get all used fields for the new move
           ...useBetaMoveMutations_all_betaMoveNode
 
@@ -190,15 +191,9 @@ function useBetaMoveMutations(betaKey: useBetaMoveMutations_betaNode$key): {
               },
             },
           },
-          onCompleted(data) {
-            // Move the stance to the new move. It'd be nice to do this
-            // optimistically, but that's not easy to integrate with optimisticResponse
-            if (isDefined(data.createBetaMove)) {
-              selectStance(data.createBetaMove.id);
-            }
-          },
-          // Punting on optimistic update because ordering is hard
         });
+        // Update stance optimistically (which is why we use order)
+        selectStance(newOrder);
       },
       state: createBetaMoveState,
     },

--- a/ui/src/util/func.ts
+++ b/ui/src/util/func.ts
@@ -62,29 +62,6 @@ export function clamp(value: number, min: number, max: number): number {
 }
 
 /**
- * Get the last element in an array. This may seem pointless, but the typing
- * is more realistic, since Typescript pretends that array indices are
- * guaranteed to be valid.
- * @param array Array to index
- * @returns Last element in the array, or undefined if the array is empty
- */
-export function last<T>(array: ReadonlyArray<T>): T | undefined {
-  return array[array.length - 1];
-}
-
-/**
- * Get an array of a range of numbers
- * @param start First number in the range (inclusive)
- * @param stop First number *not* in the range (i.e. exclusive bound)
- * @returns Array of [start, ..., stop - 1]
- */
-export function range(start: number, stop: number): number[] {
-  return Array(stop - start)
-    .fill(0)
-    .map((e, i) => start + i);
-}
-
-/**
  * Slide an element up or down an array, *mutating the array*
  */
 export function moveArrayElement<T>(


### PR DESCRIPTION
Allows for optistic stance updates and stance rollback when deleting a move. Hopefully this makes the UI feel more responsive.